### PR TITLE
Fix plex url and mount point

### DIFF
--- a/entertainment/README.md
+++ b/entertainment/README.md
@@ -100,7 +100,7 @@ docker create \
   -e VERSION=latest \
   -e PUID=<UID> -e PGID=<GID> \
   -e TZ=<timezone> \
-  -v </path/to/volumes>/plex:/config \
+  -v </path/to/volumes>/plex/config:/config \
   -v </path/to/volumes>/plex:/transcode \
   linuxserver/plex
 ```
@@ -108,7 +108,7 @@ The important part is related to the `--net=host` parameter. This way the contai
 actually using the host network. This way the container effectively runs on the same subnet as our.
 
 You can now connect to your plex instance :
-  1. Open browser to http://localhost:32400/
+  1. Open browser to http://localhost:32400/web/index.html
   1. Complete the setup
   1. If all went well, you can now stop the container
 


### PR DESCRIPTION
The plex config in the initial setup should be mounted in the same folder as the docker-compose mount it in the script. Also, the url should point straight to the html to ensure it works in all computers.
Very nice composer, have a nice day :)